### PR TITLE
Migrated Tests to Pester 5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Migrated `tests/QA/module.tests.ps1` to Pester 5 syntax using
+  `BeforeDiscovery`/`BeforeAll` blocks, `-ForEach` instead of `foreach`
+  loops for dynamic `Describe` blocks, and updated all legacy `Should`
+  assertions to use the dash-parameter syntax.
 - Updated build files to newest version of Sampler (PR #12).
 - Added GitHub issue templates and pull request template for better
   contribution guidelines.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix incorrect module manifest `Description` which referenced
   Datum.ProtectedData instead of describing this module's actual purpose.
+- Fix PSScriptAnalyzer `PSUseProcessBlockForPipelineCommand` warning in
+  `Invoke-InvokeCommandAction` and `Test-InvokeCommandFilter` by wrapping
+  the function body in a `process` block.
+
+### Removed
+
+- **Breaking:** Remove unused parameter `ProjectPath` from
+  `Invoke-InvokeCommandAction` to resolve PSScriptAnalyzer
+  `PSReviewUnusedParameter` warning.
 
 ### Added
 

--- a/RequiredModules.psd1
+++ b/RequiredModules.psd1
@@ -2,7 +2,7 @@
 
     InvokeBuild                    = 'latest'
     PSScriptAnalyzer               = 'latest'
-    Pester                         = '4.10.1'
+    Pester                         = 'latest'
     Plaster                        = 'latest'
     ModuleBuilder                  = 'latest'
     ChangelogManagement            = 'latest'

--- a/source/Private/Get-DatumCurrentNode.ps1
+++ b/source/Private/Get-DatumCurrentNode.ps1
@@ -22,6 +22,12 @@ function Get-DatumCurrentNode
     .NOTES
     This is a private function and is not exported by the module.
 
+    .EXAMPLE
+    Get-DatumCurrentNode -File (Get-Item 'C:\Config\DscConfigData\AllNodes\Dev\DSCFile01.yml')
+
+    Returns the resolved node data for 'DSCFile01' by reading the YAML file and
+    performing an RSOP resolution.
+
     .LINK
     Invoke-InvokeCommandAction
     #>

--- a/source/Private/Get-RelativeNodeFileName.ps1
+++ b/source/Private/Get-RelativeNodeFileName.ps1
@@ -25,10 +25,16 @@ function Get-RelativeNodeFileName
     .NOTES
     This is a private function and is not exported by the module.
 
+    .EXAMPLE
+    Get-RelativeNodeFileName -Path 'C:\Config\DscConfigData\AllNodes\Dev\DSCFile01.yml'
+
+    Returns 'AllNodes\Dev\DSCFile01' when the current location is 'C:\Config'.
+
     .LINK
     Invoke-InvokeCommandAction
     #>
     [CmdletBinding()]
+    [OutputType([string])]
     param (
         [Parameter(Mandatory = $true)]
         [AllowEmptyString()]

--- a/source/Private/Get-ValueKind.ps1
+++ b/source/Private/Get-ValueKind.ps1
@@ -57,7 +57,7 @@ function Get-ValueKind
     $errors = $null
     $tokens = $null
 
-    $ast = [System.Management.Automation.Language.Parser]::ParseInput(
+    $null = [System.Management.Automation.Language.Parser]::ParseInput(
         $InputObject,
         [ref]$tokens,
         [ref]$errors

--- a/source/Private/Invoke-InvokeCommandActionInternal.ps1
+++ b/source/Private/Invoke-InvokeCommandActionInternal.ps1
@@ -34,12 +34,19 @@ function Invoke-InvokeCommandActionInternal
     This is a private function and is not exported by the module. It is called exclusively by
     `Invoke-InvokeCommandAction`.
 
+    .EXAMPLE
+    Invoke-InvokeCommandActionInternal -DatumType @{ Kind = 'ScriptBlock'; Value = '{ Get-Date }' } -Datum $datum
+
+    Invokes the script block and returns the current date/time.
+
     .LINK
     https://github.com/raandree/Datum.InvokeCommand
 
     .LINK
     Invoke-InvokeCommandAction
     #>
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidGlobalVars', 'global:CurrentDatumNode')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidGlobalVars', 'global:CurrentDatumFile')]
     param (
         [Parameter(Mandatory = $true)]
         [hashtable]

--- a/source/Public/Invoke-InvokeCommandAction.ps1
+++ b/source/Public/Invoke-InvokeCommandAction.ps1
@@ -43,10 +43,6 @@ function Invoke-InvokeCommandAction
     attempts to resolve the node from the file path using `Get-DatumCurrentNode`. This is made
     available as `$Node` within embedded commands.
 
-    .PARAMETER ProjectPath
-    The root path of the DSC configuration project. Used to resolve relative paths within
-    embedded commands.
-
     .EXAMPLE
     $value = '[x={ Get-Date }=]'
     Invoke-InvokeCommandAction -InputObject $value
@@ -115,15 +111,12 @@ function Invoke-InvokeCommandAction
 
         [Parameter(ValueFromPipelineByPropertyName = $true)]
         [object]
-        $Node,
-
-        [Parameter()]
-        [string]
-        $ProjectPath
-
+        $Node
     )
 
-    $throwOnError = [bool]$datum.__Definition.DatumHandlersThrowOnError
+    process
+    {
+        $throwOnError = [bool]$datum.__Definition.DatumHandlersThrowOnError
 
     if ($InputObject -is [array])
     {
@@ -224,5 +217,6 @@ function Invoke-InvokeCommandAction
     else
     {
         $returnValue
+    }
     }
 }

--- a/source/Public/Test-InvokeCommandFilter.ps1
+++ b/source/Public/Test-InvokeCommandFilter.ps1
@@ -79,7 +79,9 @@ function Test-InvokeCommandFilter
         $ReturnValue
     )
 
-    if ($InputObject -is [string])
+    process
+    {
+        if ($InputObject -is [string])
     {
         $all = $datumInvokeCommandRegEx.Match($InputObject.Trim()).Groups['0'].Value
         $content = $datumInvokeCommandRegEx.Match($InputObject.Trim()).Groups['Content'].Value
@@ -100,5 +102,6 @@ function Test-InvokeCommandFilter
     else
     {
         return $false
+    }
     }
 }

--- a/tests/QA/module.tests.ps1
+++ b/tests/QA/module.tests.ps1
@@ -1,112 +1,141 @@
-$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+BeforeDiscovery {
+    $ProjectPath = "$PSScriptRoot\..\.." | Convert-Path
+    $ProjectName = (Get-ChildItem $ProjectPath\*\*.psd1 | Where-Object {
+            ($_.Directory.Name -match 'source|src' -or $_.Directory.Name -eq $_.BaseName) -and
+            $(try { Test-ModuleManifest $_.FullName -ErrorAction Stop } catch { $false })
+        }
+    ).BaseName
 
-# Convert-path required for PS7 or Join-Path fails
-$ProjectPath = "$here\..\.." | Convert-Path
-$ProjectName = (Get-ChildItem $ProjectPath\*\*.psd1 | Where-Object {
-    ($_.Directory.Name -match 'source|src' -or $_.Directory.Name -eq $_.BaseName) -and
-    $(try { Test-ModuleManifest $_.FullName -ErrorAction Stop }catch{$false}) }
-).BaseName
-
-$SourcePath = (Get-ChildItem $ProjectPath\*\*.psd1 | Where-Object {
-        ($_.Directory.Name -match 'source|src' -or $_.Directory.Name -eq $_.BaseName) -and
-        $(try { Test-ModuleManifest $_.FullName -ErrorAction Stop }catch { $false }) }
+    $SourcePath = (Get-ChildItem $ProjectPath\*\*.psd1 | Where-Object {
+            ($_.Directory.Name -match 'source|src' -or $_.Directory.Name -eq $_.BaseName) -and
+            $(try { Test-ModuleManifest $_.FullName -ErrorAction Stop } catch { $false })
+        }
     ).Directory.FullName
 
-$mut = Import-Module -Name $ProjectName -ErrorAction Stop -PassThru -Force | Where-Object {$_.Path -notmatch 'ScriptsToProcess.Resolve-NodeProperty.ps1'}
-$allModuleFunctions = &$mut {Get-Command -Module $args[0] -CommandType Function } $ProjectName
+    $mut = Import-Module -Name $ProjectName -ErrorAction Stop -PassThru -Force |
+        Where-Object { $_.Path -notmatch 'ScriptsToProcess.Resolve-NodeProperty.ps1' }
+    $script:allModuleFunctions = & $mut { Get-Command -Module $args[0] -CommandType Function } $ProjectName
 
-    Describe 'Changelog Management' -Tag 'Changelog' {
-        It 'Changelog has been updated' -skip:(
-            !([bool](Get-Command git -EA SilentlyContinue) -and
-              [bool](&(Get-Process -id $PID).Path -NoProfile -Command 'git rev-parse --is-inside-work-tree 2>$null'))
-            ) {
-            # Get the list of changed files compared with master
-            $HeadCommit = &git rev-parse HEAD
-            $MasterCommit = &git rev-parse origin/master
-            $filesChanged = &git @('diff',"$MasterCommit...$HeadCommit", '--name-only')
-
-            if ($HeadCommit -ne $MasterCommit) { # if we're not testing same commit (i.e. master..master)
-                $filesChanged.Where{ (Split-Path $_ -Leaf) -match '^changelog' } | Should -Not -BeNullOrEmpty
-            }
+    if (Get-Command Invoke-ScriptAnalyzer -ErrorAction SilentlyContinue)
+    {
+        $script:scriptAnalyzerRules = Get-ScriptAnalyzerRule
+    }
+    else
+    {
+        if ($ErrorActionPreference -ne 'Stop')
+        {
+            Write-Warning 'ScriptAnalyzer not found!'
         }
-
-        It 'Changelog format compliant with keepachangelog format' -skip:(![bool](Get-Command git -EA SilentlyContinue)) {
-            { Get-ChangelogData (Join-Path $ProjectPath 'CHANGELOG.md') -ErrorAction Stop } | Should -Not -Throw
+        else
+        {
+            throw 'ScriptAnalyzer not found!'
         }
     }
 
-    Describe 'General module control' -Tags 'FunctionalQuality' {
+    $script:functionTestData = $script:allModuleFunctions | ForEach-Object {
+        $functionFile = Get-ChildItem -Path $SourcePath -Recurse -Include "$($_.Name).ps1"
 
-        It 'imports without errors' {
-            { Import-Module -Name $ProjectName -Force -ErrorAction Stop } | Should -Not -Throw
-            Get-Module $ProjectName | Should -Not -BeNullOrEmpty
+        $ast = [System.Management.Automation.Language.Parser]::ParseInput(
+            (Get-Content -Raw $functionFile.FullName), [ref]$null, [ref]$null
+        )
+        $astDelegate = { $args[0] -is [System.Management.Automation.Language.FunctionDefinitionAst] }
+        $parsedFunction = $ast.FindAll($astDelegate, $true) | Where-Object Name -EQ $_.Name
+        $parameters = @($parsedFunction.Body.ParamBlock.Parameters.Name.VariablePath.ForEach{ $_.ToString() })
+
+        @{
+            FunctionName     = $_.Name
+            FunctionFilePath = $functionFile.FullName
+            Parameters       = $parameters
         }
+    }
+}
 
-        It 'Removes without error' {
-            { Remove-Module -Name $ProjectName -ErrorAction Stop } | Should -not -Throw
-            Get-Module $ProjectName | Should -beNullOrEmpty
+BeforeAll {
+    $ProjectPath = "$PSScriptRoot\..\.." | Convert-Path
+    $ProjectName = (Get-ChildItem $ProjectPath\*\*.psd1 | Where-Object {
+            ($_.Directory.Name -match 'source|src' -or $_.Directory.Name -eq $_.BaseName) -and
+            $(try { Test-ModuleManifest $_.FullName -ErrorAction Stop } catch { $false })
+        }
+    ).BaseName
+}
+
+Describe 'Changelog Management' -Tag 'Changelog' {
+    It 'Changelog has been updated' -Skip:(
+        !([bool](Get-Command git -EA SilentlyContinue) -and
+          [bool](& (Get-Process -Id $PID).Path -NoProfile -Command 'git rev-parse --is-inside-work-tree 2>$null'))
+        ) {
+        # Get the list of changed files compared with master
+        $HeadCommit = & git rev-parse HEAD
+        $MasterCommit = & git rev-parse origin/master
+        $filesChanged = & git @('diff', "$MasterCommit...$HeadCommit", '--name-only')
+
+        if ($HeadCommit -ne $MasterCommit) {
+            # if we're not testing same commit (i.e. master..master)
+            $filesChanged.Where{ (Split-Path $_ -Leaf) -match '^changelog' } | Should -Not -BeNullOrEmpty
         }
     }
 
-    if (Get-Command Invoke-ScriptAnalyzer -ErrorAction SilentlyContinue) {
-        $scriptAnalyzerRules = Get-ScriptAnalyzerRule
+    It 'Changelog format compliant with keepachangelog format' -Skip:(![bool](Get-Command git -EA SilentlyContinue)) {
+        { Get-ChangelogData (Join-Path $ProjectPath 'CHANGELOG.md') -ErrorAction Stop } | Should -Not -Throw
     }
-    else {
-        if ($ErrorActionPreference -ne 'Stop') {
-            Write-Warning "ScriptAnalyzer not found!"
-        }
-        else {
-            Throw "ScriptAnalyzer not found!"
-        }
+}
+
+Describe 'General module control' -Tags 'FunctionalQuality' {
+
+    It 'imports without errors' {
+        { Import-Module -Name $ProjectName -Force -ErrorAction Stop } | Should -Not -Throw
+        Get-Module $ProjectName | Should -Not -BeNullOrEmpty
     }
 
-    foreach ($function in $allModuleFunctions) {
-        $functionFile = Get-ChildItem -path $SourcePath -Recurse -Include "$($function.Name).ps1"
-        Describe "Quality for $($function.Name)" -Tags 'TestQuality' {
-            It "$($function.Name) has a unit test" {
-                Get-ChildItem "tests\" -recurse -include "$($function.Name).Tests.ps1" | Should Not BeNullOrEmpty
-            }
-
-            if ($scriptAnalyzerRules) {
-                It "Script Analyzer for $($functionFile.FullName)" {
-                    $PSSAResult = (Invoke-ScriptAnalyzer -Path $functionFile.FullName)
-                    $Report = $PSSAResult | Format-Table -AutoSize | Out-String -Width 110
-                    $PSSAResult  | Should -BeNullOrEmpty -Because `
-                        "some rule triggered.`r`n`r`n $Report"
-                }
-
-            }
-        }
-
-        Describe "Help for $($function.Name)" -Tags 'helpQuality' {
-            $AbstractSyntaxTree = [System.Management.Automation.Language.Parser]::
-            ParseInput((Get-Content -raw $functionFile.FullName), [ref]$null, [ref]$null)
-            $AstSearchDelegate = { $args[0] -is [System.Management.Automation.Language.FunctionDefinitionAst] }
-            $ParsedFunction = $AbstractSyntaxTree.FindAll( $AstSearchDelegate, $true ) |
-                ? Name -eq $function.Name
-
-            $FunctionHelp = $ParsedFunction.GetHelpContent()
-
-            It 'Has a SYNOPSIS' {
-                $FunctionHelp.Synopsis | should not BeNullOrEmpty
-            }
-
-            It 'Has a Description, with length > 40' {
-                $FunctionHelp.Description.Length | Should beGreaterThan 40
-            }
-
-            It 'Has at least 1 example' {
-                $FunctionHelp.Examples.Count | Should beGreaterThan 0
-                $FunctionHelp.Examples[0] | Should match ([regex]::Escape($function.Name))
-                $FunctionHelp.Examples[0].Length | Should BeGreaterThan ($function.Name.Length + 10)
-            }
-
-            $parameters = $ParsedFunction.Body.ParamBlock.Parameters.name.VariablePath.Foreach{ $_.ToString() }
-            foreach ($parameter in $parameters) {
-                It "Has help for Parameter: $parameter" {
-                    $FunctionHelp.Parameters.($parameter.ToUpper()) | Should Not BeNullOrEmpty
-                    $FunctionHelp.Parameters.($parameter.ToUpper()).Length | Should BeGreaterThan 25
-                }
-            }
-        }
+    It 'Removes without error' {
+        { Remove-Module -Name $ProjectName -ErrorAction Stop } | Should -Not -Throw
+        Get-Module $ProjectName | Should -BeNullOrEmpty
     }
+}
+
+Describe 'Quality for <FunctionName>' -Tags 'TestQuality' -ForEach $script:functionTestData {
+
+    It '<FunctionName> has a unit test' {
+        Get-ChildItem 'tests\' -Recurse -Include "$FunctionName.Tests.ps1" | Should -Not -BeNullOrEmpty
+    }
+
+    It 'Script Analyzer for <FunctionFilePath>' -Skip:(-not $script:scriptAnalyzerRules) {
+        $PSSAResult = Invoke-ScriptAnalyzer -Path $FunctionFilePath
+        $Report = $PSSAResult | Format-Table -AutoSize | Out-String -Width 110
+        $PSSAResult | Should -BeNullOrEmpty -Because `
+            "some rule triggered.`r`n`r`n $Report"
+    }
+}
+
+Describe 'Help for <FunctionName>' -Tags 'helpQuality' -ForEach $script:functionTestData {
+
+    BeforeAll {
+        $functionFile = Get-Item -Path $FunctionFilePath
+        $AbstractSyntaxTree = [System.Management.Automation.Language.Parser]::
+            ParseInput((Get-Content -Raw $functionFile.FullName), [ref]$null, [ref]$null)
+        $AstSearchDelegate = { $args[0] -is [System.Management.Automation.Language.FunctionDefinitionAst] }
+        $ParsedFunction = $AbstractSyntaxTree.FindAll($AstSearchDelegate, $true) |
+            Where-Object Name -EQ $FunctionName
+
+        $script:FunctionHelp = $ParsedFunction.GetHelpContent()
+    }
+
+    It 'Has a SYNOPSIS' {
+        $script:FunctionHelp.Synopsis | Should -Not -BeNullOrEmpty
+    }
+
+    It 'Has a Description, with length > 40' {
+        $script:FunctionHelp.Description.Length | Should -BeGreaterThan 40
+    }
+
+    It 'Has at least 1 example' {
+        $script:FunctionHelp.Examples.Count | Should -BeGreaterThan 0
+        $script:FunctionHelp.Examples[0] | Should -Match ([regex]::Escape($FunctionName))
+        $script:FunctionHelp.Examples[0].Length | Should -BeGreaterThan ($FunctionName.Length + 10)
+    }
+
+    It 'Has help for Parameter: <_>' -ForEach $Parameters {
+        $script:FunctionHelp.Parameters.($_.ToUpper()) | Should -Not -BeNullOrEmpty
+        $script:FunctionHelp.Parameters.($_.ToUpper()).Length | Should -BeGreaterThan 25
+    }
+}

--- a/tests/Unit/Get-RelativeNodeFileName.tests.ps1
+++ b/tests/Unit/Get-RelativeNodeFileName.tests.ps1
@@ -1,0 +1,42 @@
+BeforeAll {
+    Import-Module -Name $ProjectPath\tests\TestHelpers.psm1 -Force
+    Import-Module -Name Datum.InvokeCommand -Force
+}
+
+InModuleScope Datum.InvokeCommand {
+
+    Describe 'Get-RelativeNodeFileName tests' {
+
+        It 'Returns an empty string when the path is empty' {
+            $result = Get-RelativeNodeFileName -Path ''
+
+            $result | Should -Be ([string]::Empty)
+        }
+
+        It 'Returns a relative node path from an absolute path' {
+            Push-Location -Path TestDrive:\
+
+            $dir = New-Item -Path 'TestDrive:\DscConfigData\AllNodes\Dev' -ItemType Directory -Force
+            $file = New-Item -Path "$($dir.FullName)\DSCFile01.yml" -ItemType File -Force
+
+            $result = Get-RelativeNodeFileName -Path $file.FullName
+
+            $result | Should -Be 'AllNodes\Dev\DSCFile01'
+
+            Pop-Location
+        }
+
+        It 'Removes the file extension from the last segment' {
+            Push-Location -Path TestDrive:\
+
+            $dir = New-Item -Path 'TestDrive:\DscConfigData\AllNodes' -ItemType Directory -Force
+            $file = New-Item -Path "$($dir.FullName)\Server01.yml" -ItemType File -Force
+
+            $result = Get-RelativeNodeFileName -Path $file.FullName
+
+            $result | Should -Not -Match '\.yml$'
+
+            Pop-Location
+        }
+    }
+}

--- a/tests/Unit/Test-InvokeCommandFilter.tests.ps1
+++ b/tests/Unit/Test-InvokeCommandFilter.tests.ps1
@@ -1,0 +1,49 @@
+BeforeAll {
+    Import-Module -Name $ProjectPath\tests\TestHelpers.psm1 -Force
+    Import-Module -Name Datum.InvokeCommand -Force
+}
+
+Describe 'Test-InvokeCommandFilter tests' {
+
+    It 'Returns $true for a valid embedded command string' {
+        $result = Test-InvokeCommandFilter -InputObject '[x={ Get-Date }=]'
+
+        $result | Should -BeTrue
+    }
+
+    It 'Returns $false for a plain string without embedded commands' {
+        $result = Test-InvokeCommandFilter -InputObject 'Just a regular string'
+
+        $result | Should -BeFalse
+    }
+
+    It 'Returns $false for a non-string input' {
+        $result = Test-InvokeCommandFilter -InputObject 42
+
+        $result | Should -BeFalse
+    }
+
+    It 'Returns $false for $null input' {
+        $result = Test-InvokeCommandFilter -InputObject $null
+
+        $result | Should -BeFalse
+    }
+
+    It 'Returns the matched string when -ReturnValue is specified' {
+        $result = Test-InvokeCommandFilter -InputObject '[x={ Get-Date }=]' -ReturnValue
+
+        $result | Should -Be '[x={ Get-Date }=]'
+    }
+
+    It 'Returns $true for an expandable string command' {
+        $result = Test-InvokeCommandFilter -InputObject '[x="$($Node.Name)"=]'
+
+        $result | Should -BeTrue
+    }
+
+    It 'Accepts pipeline input' {
+        $result = '[x={ Get-Date }=]' | Test-InvokeCommandFilter
+
+        $result | Should -BeTrue
+    }
+}


### PR DESCRIPTION
# Pull Request

Migrated Tests to Pester 5

## Pull Request (PR) description

see changelog.md

## Task list

- [x] The PR represents a single logical change. i.e. Cosmetic updates should go in different PRs.
- [x] Added an entry under the Unreleased section of in the CHANGELOG.md as per [format](https://keepachangelog.com/en/1.0.0/).
- [x] Local clean build passes without issue or fail tests (`build.ps1 -ResolveDependency`).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).
